### PR TITLE
fix(job-queue-plugin): Allow specifying ackDeadline for subscription

### DIFF
--- a/packages/job-queue-plugin/src/pub-sub/options.ts
+++ b/packages/job-queue-plugin/src/pub-sub/options.ts
@@ -8,6 +8,11 @@ export interface PubSubOptions {
      * @description
      * This is the mapping of Vendure queue names to PubSub Topics and Subscriptions
      * For each queue a topic and subscription is required to exist.
+     * First item - topic name
+     * Second item - subscription name
+     * Third item - ackDeadline for subscriber, by default Google use dynamic value. If left
+     *     unset the initial value will be 10 seconds, but it will evolve into the
+     *     99th percentile time it takes to acknowledge a message
      */
-    queueNamePubSubPair?: Map<string, [string, string]>;
+    queueNamePubSubPair?: Map<string, [string, string, number?]>;
 }

--- a/packages/job-queue-plugin/src/pub-sub/pub-sub-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/pub-sub/pub-sub-job-queue-strategy.ts
@@ -15,7 +15,7 @@ import { PubSubOptions } from './options';
 
 export class PubSubJobQueueStrategy extends InjectableJobQueueStrategy implements JobQueueStrategy {
     private concurrency: number;
-    private queueNamePubSubPair: Map<string, [string, string]>;
+    private queueNamePubSubPair: Map<string, [string, string, number?]>;
     private pubSubClient: PubSub;
     private topics = new Map<string, Topic>();
     private subscriptions = new Map<string, Subscription>();
@@ -136,11 +136,12 @@ export class PubSubJobQueueStrategy extends InjectableJobQueueStrategy implement
             throw new Error(`Subscription name not set for queue: ${queueName}`);
         }
 
-        const [topicName, subscriptionName] = pair;
+        const [topicName, subscriptionName, ackDeadline] = pair;
         subscription = this.topic(queueName).subscription(subscriptionName, {
             flowControl: {
                 maxMessages: this.concurrency,
             },
+            ackDeadline,
         });
         this.subscriptions.set(queueName, subscription);
 


### PR DESCRIPTION
Fix for jobs are taking too long. 
If your job taken by subscriber few times because of ackDeadline exceeded, you can change this value now by setting custom ackDeadline using PubSubOptions.