### PR TITLE
feature(core): Introduce the CacheManagerModule and add it to PluginC…

### DIFF
--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -1,10 +1,11 @@
-import { CacheModule, CACHE_MANAGER, DynamicModule } from '@nestjs/common';
+import { CACHE_MANAGER, DynamicModule } from '@nestjs/common';
 import { GqlModuleOptions, GraphQLModule, GraphQLTypesLoader } from '@nestjs/graphql';
 import { notNullOrUndefined } from '@vendure/common/lib/shared-utils';
 import { Cache } from 'cache-manager';
 import { buildSchema, extendSchema, GraphQLSchema, printSchema, stripIgnoredCharacters, ValidationContext } from 'graphql';
 import path from 'path';
 
+import { CacheManagerModule } from '../../config/cache-manager.module';
 import { ConfigModule } from '../../config/config.module';
 import { ConfigService } from '../../config/config.service';
 import { I18nModule } from '../../i18n/i18n.module';
@@ -77,13 +78,7 @@ export function configureGraphQLModule(
             CustomFieldRelationResolverService,
             CACHE_MANAGER
         ],
-        imports: [ConfigModule, I18nModule, ApiSharedModule, ServiceModule.forRoot(), CacheModule.registerAsync({
-            imports: [ConfigModule],
-            useFactory: async (configService: ConfigService) => {
-                return configService.cacheOptions;
-            },
-            inject: [ConfigService],
-        })],
+        imports: [ConfigModule, I18nModule, ApiSharedModule, ServiceModule.forRoot(), CacheManagerModule],
     });
 }
 

--- a/packages/core/src/config/cache-manager.module.ts
+++ b/packages/core/src/config/cache-manager.module.ts
@@ -1,0 +1,23 @@
+import { CacheModule, Module } from '@nestjs/common';
+
+import { ConfigModule } from './config.module';
+import { ConfigService } from './config.service';
+
+/**
+ * The coreCacheModule is imported internally by the CacheManagerModule. It is arranged in this way so that
+ * there is only a single instance of this module being instantiated, and thus the lifecycle hooks will
+ * only run a single time.
+ */
+const coreCacheModule = CacheModule.registerAsync({
+    imports: [ConfigModule],
+    useFactory: async (configService: ConfigService) => {
+        return configService.cacheOptions;
+    },
+    inject: [ConfigService],
+})
+
+@Module({
+    imports: [coreCacheModule],
+    exports: [coreCacheModule],
+})
+export class CacheManagerModule {}

--- a/packages/core/src/plugin/plugin-common.module.ts
+++ b/packages/core/src/plugin/plugin-common.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { CacheModule } from '../cache/cache.module';
+import { CacheManagerModule } from '../config/cache-manager.module';
 import { ConfigModule } from '../config/config.module';
 import { EventBusModule } from '../event-bus/event-bus.module';
 import { HealthCheckModule } from '../health-check/health-check.module';
@@ -31,6 +32,7 @@ import { ServiceModule } from '../service/service.module';
         JobQueueModule,
         HealthCheckModule,
         CacheModule,
+        CacheManagerModule
     ],
     exports: [
         EventBusModule,
@@ -39,6 +41,7 @@ import { ServiceModule } from '../service/service.module';
         JobQueueModule,
         HealthCheckModule,
         CacheModule,
+        CacheManagerModule
     ],
 })
 export class PluginCommonModule {}


### PR DESCRIPTION
* Introduce the **CacheManagerModule** exporting the instance of the **cache-manager** module.
* Add the **CacheManagerModule** to the **PluginCommonModule** so the **cache-manager** instance would be available from a Vendure plugin.
This would allow using a single Redis instance in the `@vendure/core` and `klekt-vendure`.